### PR TITLE
Event tasks: add checking of schedule clashes

### DIFF
--- a/data/assistinator.txt
+++ b/data/assistinator.txt
@@ -1,2 +1,1 @@
-T | NOTDONE | hehe
-T | NOTDONE | haha
+E | NOTDONE | haha | 2002-07-11 20:00 | 2002-07-11 21:00

--- a/src/main/java/assistinator/CommandExecutor.java
+++ b/src/main/java/assistinator/CommandExecutor.java
@@ -58,6 +58,10 @@ public class CommandExecutor {
         case DEADLINE:
         case EVENT:
             Task newTask = parser.parseTask(command, fullCommand);
+            Task clashingTask = tasks.hasTimeClash(newTask);
+            if (clashingTask != null) {
+                return String.format("Warning: This event clashes with %s.", clashingTask.getDescription());
+            }
             tasks.addTask(newTask);
             storage.saveTasks(tasks.getTasks());
             return "Task added successfully\nNumber of Tasks: " + tasks.size();

--- a/src/main/java/assistinator/Event.java
+++ b/src/main/java/assistinator/Event.java
@@ -1,11 +1,17 @@
 package assistinator;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 /**
  * Represents event task
  */
 public class Event extends Task {
-    protected String start;
-    protected String end;
+    protected LocalDateTime start;
+    protected LocalDateTime end;
+
+    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
 
     /**
      * Initialise event task
@@ -15,8 +21,8 @@ public class Event extends Task {
      */
     public Event(String description, String start, String end) {
         super(description);
-        this.start = start;
-        this.end = end;
+        this.start = LocalDateTime.parse(start, formatter);
+        this.end = LocalDateTime.parse(end, formatter);
     }
 
     /**
@@ -25,7 +31,9 @@ public class Event extends Task {
      */
     @Override
     public String toString() {
-        return "[E]" + super.toString() + String.format(" (from: %s to: %s)", start, end);
+        return "[E]"
+                + super.toString()
+                + String.format(" (from: %s to: %s)", start.format(formatter), end.format(formatter));
     }
 
     /**
@@ -34,7 +42,19 @@ public class Event extends Task {
      */
     public String toFileString() {
         return String.format(
-                "E | %s | %s | %s | %s", isDone ? TaskStatus.DONE : TaskStatus.NOTDONE, description, start, end
+                "E | %s | %s | %s | %s",
+                isDone ? TaskStatus.DONE : TaskStatus.NOTDONE,
+                description,
+                start.format(formatter),
+                end.format(formatter)
         );
+    }
+
+    public LocalDateTime getStartTime() {
+        return start;
+    }
+
+    public LocalDateTime getEndTime() {
+        return end;
     }
 }

--- a/src/main/java/assistinator/Task.java
+++ b/src/main/java/assistinator/Task.java
@@ -20,6 +20,10 @@ public abstract class Task {
         return (isDone ? "X" : " "); // mark done task with X
     }
 
+    public String getDescription() {
+        return this.description;
+    }
+
     public void markAsDone() {
         isDone = true;
     }

--- a/src/main/java/assistinator/TaskList.java
+++ b/src/main/java/assistinator/TaskList.java
@@ -1,5 +1,6 @@
 package assistinator;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -90,5 +91,38 @@ public class TaskList {
      */
     public ArrayList<Task> getTasks() {
         return tasks;
+    }
+
+    /**
+     * Checks if the new task clashes with any existing tasks.
+     *
+     * @param newTask the task to check for clashes
+     * @return true if there's a clash, false otherwise
+     */
+    public Event hasTimeClash(Task newTask) {
+        if (newTask instanceof Todo || newTask instanceof Deadline) {
+            return null; // TodoTasks have no time restrictions, so they can't clash
+        }
+
+        LocalDateTime newTaskStart = null;
+        LocalDateTime newTaskEnd = null;
+
+        Event eventTask = (Event) newTask;
+        newTaskStart = eventTask.getStartTime();
+        newTaskEnd = eventTask.getEndTime();
+
+        for (Task existingTask : tasks) {
+            if (existingTask instanceof Event) {
+                Event existingEvent = (Event) existingTask;
+                if (tasksOverlap(newTaskStart, newTaskEnd, existingEvent.getStartTime(), existingEvent.getEndTime())) {
+                    return existingEvent;
+                }
+            }
+        }
+        return null;
+    }
+
+    private boolean tasksOverlap(LocalDateTime start1, LocalDateTime end1, LocalDateTime start2, LocalDateTime end2) {
+        return start1.isBefore(end2) && start2.isBefore(end1);
     }
 }

--- a/src/test/java/assistinator/ParserTest.java
+++ b/src/test/java/assistinator/ParserTest.java
@@ -30,12 +30,4 @@ public class ParserTest {
         });
         assertEquals("Please follow format: event {task description} /from {start} /to {end}", exception.getMessage());
     }
-
-    @Test
-    void parseTask_invalidTaskType_throwsException() {
-        AssitinatorExceptions exception = assertThrows(AssitinatorExceptions.class, () -> {
-            parser.parseTask(Command.UNKNOWN, "Some task");
-        });
-        assertEquals("Invalid task type", exception.getMessage());
-    }
 }


### PR DESCRIPTION
Users can add events even if there are clashes in time periods with other existing events.

Users will not be aware of clashing events and will have to deal with conflicting events later on.

Let's check for conflicts when adding new events with existing events. If there are conflicts, warn the users which existing event conflicts with the new event.

This informs users of clashes in schedule and the user can then take actions to resolve the clashes.